### PR TITLE
Migrar ejercicio de MLP y añadir interfaz web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+.venv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-# red-neuronal-lenguaje
+# Intérprete de MLP y entrenamiento en MNIST
+
+Este repositorio traslada el trabajo realizado en Google Colab a un proyecto estructurado en Git. Incluye:
+
+- Una implementación *forward* de un perceptrón multicapa usando solo NumPy.
+- Un mini-lenguaje textual y su intérprete para generar modelos de `tf.keras.Sequential`.
+- Utilidades para entrenar y evaluar el modelo sobre MNIST desde la línea de comandos.
+- Una interfaz web sencilla (Flask) para experimentar con arquitecturas y lanzar entrenamientos sin salir del navegador.
+
+## Requisitos
+
+```bash
+python >= 3.9
+pip install -r requirements.txt
+```
+
+> **Nota**: TensorFlow puede tardar en instalarse dependiendo de la plataforma. Si cuentas con GPU puedes instalar `tensorflow-gpu`.
+
+## Estructura
+
+```
+.
+├── docs/analysis.md          # Respuestas a las preguntas de reflexión
+├── scripts/train_mnist.py    # Script CLI para entrenar modelos
+├── src/mlp_compiler/         # Paquete con el MLP NumPy y el compilador a Keras
+└── web/                      # Aplicación Flask para gestionar el ejercicio desde una web
+```
+
+## Uso desde la línea de comandos
+
+Entrena el modelo por defecto (usa 5 épocas, batch de 128, valida con el 10 %) y muestra métricas en consola:
+
+```bash
+python scripts/train_mnist.py
+```
+
+Para experimentar con otras arquitecturas basta con pasar la cadena al parámetro `--architecture`:
+
+```bash
+python scripts/train_mnist.py \
+  --architecture "Dense(256, relu) -> Dropout(0.3) -> Dense(128, relu) -> Dense(10, softmax)" \
+  --epochs 3 --train-size 10000
+```
+
+El argumento `--train-size` permite limitar la cantidad de ejemplos usados durante el entrenamiento, útil para pruebas rápidas.
+
+Si añades `--plot-path outputs/history.png` el script guardará las curvas de accuracy y pérdida.
+
+## Interfaz web
+
+1. Arranca el servidor Flask:
+
+   ```bash
+   export FLASK_APP=web.app
+   flask run
+   ```
+
+   También puedes ejecutar `python web/app.py` para modo *debug*.
+
+2. Visita `http://127.0.0.1:5000` y completa el formulario. El servidor entrenará el modelo usando 5 000 ejemplos por defecto para ofrecer una respuesta rápida y mostrará las métricas y gráficas generadas.
+
+## Mini-lenguaje soportado
+
+- `Dense(units, activation)`
+- `Dropout(rate)`
+- `Input(dim)` como nodo opcional al inicio (alternativa a pasar `input_dim` en la API).
+
+Las activaciones disponibles son `relu`, `sigmoid`, `tanh`, `softmax` y `linear`.
+
+## Referencias
+
+- [Implementación de MLP en NumPy](src/mlp_compiler/numpy_mlp.py)
+- [Compilador de arquitecturas a Keras](src/mlp_compiler/compiler.py)
+- [Carga y entrenamiento en MNIST](src/mlp_compiler/training.py)
+- [Preguntas de análisis](docs/analysis.md)

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -1,0 +1,18 @@
+# Preguntas de análisis
+
+## 1. Complejidad de implementar backpropagation a mano
+
+- **Complejidad y errores**. Derivar y codificar gradientes para cada capa es proclive a errores de signo y dimensiones.
+- **Estabilidad numérica**. Sin ayudas del framework habría que lidiar manualmente con gradientes que se desvanecen o explotan.
+- **Eficiencia**. Optimizar la vectorización, el batching y la reutilización de memoria resulta difícil sin kernels optimizados.
+- **Modularidad**. Añadir nuevas activaciones o funciones de pérdida implicaría re-derivar y probar todas las fórmulas.
+- **Depuración**. Sin herramientas de autograd, detectar el origen de NaNs o gradientes nulos es muy costoso.
+- **Hardware**. Sacar provecho de GPU/TPU manualmente supone diseñar kernels específicos.
+
+## 2. Ventajas del intérprete como capa de abstracción
+
+- **Productividad**. Probar variantes de arquitecturas es tan simple como editar una cadena de texto versionable.
+- **Legibilidad**. El mini-lenguaje concentra la arquitectura en una línea fácil de revisar en equipo.
+- **Portabilidad**. El mismo intérprete puede apuntar a backends distintos (Keras, PyTorch, JAX) sin cambiar la sintaxis.
+- **Validación temprana**. El parser detecta errores de configuración antes de lanzar un entrenamiento costoso.
+- **Automatización**. Facilita generar configuraciones automáticamente para búsquedas de hiperparámetros.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+tensorflow
+matplotlib
+flask

--- a/scripts/train_mnist.py
+++ b/scripts/train_mnist.py
@@ -1,0 +1,109 @@
+"""Command line utility to train a compiled model on MNIST."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+import matplotlib.pyplot as plt
+
+from mlp_compiler.training import TrainingResult, build_and_train
+
+
+DEFAULT_ARCHITECTURE = "Dense(300, relu) -> Dropout(0.2) -> Dense(100, relu) -> Dense(10, softmax)"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--architecture",
+        type=str,
+        default=DEFAULT_ARCHITECTURE,
+        help="Arquitectura en el mini-lenguaje textual.",
+    )
+    parser.add_argument("--epochs", type=int, default=5, help="Número de épocas de entrenamiento.")
+    parser.add_argument("--batch-size", type=int, default=128, help="Tamaño de batch.")
+    parser.add_argument(
+        "--validation-split",
+        type=float,
+        default=0.1,
+        help="Fracción del set de entrenamiento dedicada a validación.",
+    )
+    parser.add_argument(
+        "--train-size",
+        type=int,
+        default=None,
+        help="Limitar la cantidad de ejemplos de entrenamiento (para pruebas rápidas).",
+    )
+    parser.add_argument(
+        "--test-size",
+        type=int,
+        default=None,
+        help="Limitar la cantidad de ejemplos de test.",
+    )
+    parser.add_argument(
+        "--plot-path",
+        type=Path,
+        default=None,
+        help="Ruta para guardar las curvas de entrenamiento en PNG.",
+    )
+    parser.add_argument(
+        "--input-dim",
+        type=int,
+        default=784,
+        help="Dimensión de entrada para la primera capa Dense.",
+    )
+    return parser.parse_args()
+
+
+def _maybe_plot(history: TrainingResult, plot_path: Optional[Path]) -> None:
+    if plot_path is None:
+        return
+
+    plot_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+    axes[0].plot(history.history["accuracy"], label="train")
+    axes[0].plot(history.history.get("val_accuracy", []), label="val")
+    axes[0].set_title("Accuracy")
+    axes[0].set_xlabel("Época")
+    axes[0].set_ylabel("Accuracy")
+    axes[0].legend()
+    axes[0].grid(True)
+
+    axes[1].plot(history.history["loss"], label="train")
+    axes[1].plot(history.history.get("val_loss", []), label="val")
+    axes[1].set_title("Pérdida")
+    axes[1].set_xlabel("Época")
+    axes[1].set_ylabel("Loss")
+    axes[1].legend()
+    axes[1].grid(True)
+
+    fig.tight_layout()
+    fig.savefig(plot_path)
+    print(f"Curvas de entrenamiento guardadas en {plot_path}")
+
+
+def main() -> None:
+    args = parse_args()
+
+    print("Arquitectura:", args.architecture)
+    result = build_and_train(
+        args.architecture,
+        input_dim=args.input_dim,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        validation_split=args.validation_split,
+        limit_train=args.train_size,
+        limit_test=args.test_size,
+        verbose=2,
+    )
+
+    print(f"\nPrecisión en test: {result.test_accuracy:.4f}")
+    print(f"Pérdida en test: {result.test_loss:.4f}")
+
+    _maybe_plot(result, args.plot_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mlp_compiler/__init__.py
+++ b/src/mlp_compiler/__init__.py
@@ -1,0 +1,15 @@
+"""Utilities for building simple MLPs and compiling textual architectures."""
+from .activations import ACTIVATIONS, SUPPORTED_ACTIVATIONS, get_activation
+from .numpy_mlp import Layer, MLP, neuron_forward
+from .compiler import compile_model, ArchitectureError
+
+__all__ = [
+    "ACTIVATIONS",
+    "SUPPORTED_ACTIVATIONS",
+    "get_activation",
+    "Layer",
+    "MLP",
+    "neuron_forward",
+    "compile_model",
+    "ArchitectureError",
+]

--- a/src/mlp_compiler/activations.py
+++ b/src/mlp_compiler/activations.py
@@ -1,0 +1,55 @@
+"""Activation functions used in the NumPy-based MLP implementation."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def sigmoid(z: np.ndarray) -> np.ndarray:
+    """Sigmoid activation."""
+    return 1.0 / (1.0 + np.exp(-z))
+
+
+def relu(z: np.ndarray) -> np.ndarray:
+    """Rectified Linear Unit (ReLU) activation."""
+    return np.maximum(0.0, z)
+
+
+def linear(z: np.ndarray) -> np.ndarray:
+    """Identity activation."""
+    return z
+
+
+ACTIVATIONS = {
+    "sigmoid": sigmoid,
+    "relu": relu,
+    "tanh": np.tanh,
+    "linear": linear,
+}
+
+
+SUPPORTED_ACTIVATIONS = frozenset(ACTIVATIONS.keys())
+
+
+def get_activation(name: str):
+    """Return an activation function by name.
+
+    Parameters
+    ----------
+    name:
+        Name of the activation. The lookup is case-insensitive.
+
+    Returns
+    -------
+    Callable activation function.
+
+    Raises
+    ------
+    ValueError
+        If the activation name is unknown.
+    """
+
+    key = name.lower()
+    try:
+        return ACTIVATIONS[key]
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise ValueError(f"Activación desconocida: {name}") from exc

--- a/src/mlp_compiler/compiler.py
+++ b/src/mlp_compiler/compiler.py
@@ -1,0 +1,103 @@
+"""Text to Keras model compiler used in the project."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from tensorflow import keras
+from tensorflow.keras import layers
+
+_LAYER_REGEX = re.compile(r"(?P<name>[A-Za-z]+)\s*\((?P<args>[^)]*)\)\s*$")
+_SUPPORTED_ACTIVATIONS = {"relu", "sigmoid", "tanh", "softmax", "linear"}
+
+
+class ArchitectureError(ValueError):
+    """Raised when the architecture description is invalid."""
+
+
+@dataclass
+class ParsedLayer:
+    name: str
+    args: Sequence[object]
+
+
+def _parse_args(arg_str: str) -> List[object]:
+    if arg_str.strip() == "":
+        return []
+    parts = [p.strip() for p in arg_str.split(",")]
+    typed: List[object] = []
+    for p in parts:
+        if re.fullmatch(r"[+-]?\d+", p):
+            typed.append(int(p))
+        elif re.fullmatch(r"[+-]?\d*\.\d+", p):
+            typed.append(float(p))
+        else:
+            typed.append(p.lower())
+    return typed
+
+
+def _parse_layer(token: str) -> ParsedLayer:
+    match = _LAYER_REGEX.match(token)
+    if not match:
+        raise ArchitectureError(f"Capa inválida: '{token}'")
+    name = match.group("name").lower()
+    args = _parse_args(match.group("args"))
+    return ParsedLayer(name=name, args=args)
+
+
+def compile_model(architecture_string: str, input_dim: int | None = None) -> keras.Sequential:
+    """Compile a textual architecture description into a ``tf.keras.Sequential`` model."""
+
+    tokens = [tok.strip() for tok in architecture_string.split("->") if tok.strip()]
+    if not tokens:
+        raise ArchitectureError("La arquitectura no puede estar vacía")
+
+    parsed = [_parse_layer(tok) for tok in tokens]
+    model_layers: List[layers.Layer] = []
+    inferred_input_dim: int | None = None
+
+    for layer in parsed:
+        if layer.name == "input":
+            if len(layer.args) != 1 or not isinstance(layer.args[0], int):
+                raise ArchitectureError("Input(dim) requiere un entero")
+            inferred_input_dim = layer.args[0]
+            continue
+
+        if layer.name == "dense":
+            if len(layer.args) < 1:
+                raise ArchitectureError(
+                    "Dense(units, [activation]) requiere al menos el argumento 'units'."
+                )
+            units = layer.args[0]
+            if not isinstance(units, int):
+                raise ArchitectureError("El argumento 'units' debe ser entero")
+            activation = None
+            if len(layer.args) >= 2:
+                activation = layer.args[1]
+                if activation not in _SUPPORTED_ACTIVATIONS:
+                    raise ArchitectureError(f"Activación no soportada: {activation}")
+
+            if not model_layers:
+                first_input = input_dim if input_dim is not None else inferred_input_dim
+                if first_input is None:
+                    raise ArchitectureError(
+                        "La primera capa Dense requiere 'input_dim' o un nodo Input(dim)."
+                    )
+                model_layers.append(layers.Dense(units, activation=activation, input_shape=(first_input,)))
+            else:
+                model_layers.append(layers.Dense(units, activation=activation))
+            continue
+
+        if layer.name == "dropout":
+            if len(layer.args) != 1 or not isinstance(layer.args[0], (int, float)):
+                raise ArchitectureError("Dropout(rate) requiere un único valor numérico")
+            rate = float(layer.args[0])
+            if not 0 <= rate < 1:
+                raise ArchitectureError("Dropout rate debe estar entre 0 y 1")
+            model_layers.append(layers.Dropout(rate))
+            continue
+
+        raise ArchitectureError(f"Tipo de capa no soportado: {layer.name}")
+
+    return keras.Sequential(model_layers, name="compiled_from_text")

--- a/src/mlp_compiler/numpy_mlp.py
+++ b/src/mlp_compiler/numpy_mlp.py
@@ -1,0 +1,86 @@
+"""Pure NumPy implementation of a minimal MLP forward pass."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+import numpy as np
+
+from .activations import ACTIVATIONS
+
+
+def _assert_ndarray(x: np.ndarray, name: str) -> None:
+    if not isinstance(x, np.ndarray):
+        raise TypeError(f"{name} debe ser np.ndarray, recibido: {type(x)}")
+
+
+def neuron_forward(x: np.ndarray, w: np.ndarray, b: float, activation: str = "relu") -> np.ndarray:
+    """Compute the forward pass of a single neuron.
+
+    Parameters
+    ----------
+    x:
+        Input batch with shape ``(batch, in_features)``.
+    w:
+        Weight vector with shape ``(in_features,)``.
+    b:
+        Bias term as scalar.
+    activation:
+        Name of the activation function to apply.
+    """
+
+    _assert_ndarray(x, "x")
+    _assert_ndarray(w, "w")
+    if activation not in ACTIVATIONS:
+        raise ValueError(f"Activación desconocida: {activation}")
+    z = x @ w + b
+    return ACTIVATIONS[activation](z)
+
+
+@dataclass
+class Layer:
+    """Simple fully connected layer using NumPy arrays."""
+
+    in_features: int
+    out_features: int
+    activation_name: str = "relu"
+    weight_scale: float = 0.01
+
+    def __post_init__(self) -> None:
+        if self.activation_name not in ACTIVATIONS:
+            raise ValueError(f"Activación desconocida: {self.activation_name}")
+        if self.in_features <= 0 or self.out_features <= 0:
+            raise ValueError("in_features y out_features deben ser positivos")
+
+        if self.activation_name == "relu":
+            scale = np.sqrt(2.0 / self.in_features)
+        else:
+            scale = np.sqrt(1.0 / self.in_features)
+        scale *= self.weight_scale / 0.01
+
+        self.W = np.random.randn(self.in_features, self.out_features) * scale
+        self.b = np.zeros((self.out_features,), dtype=np.float64)
+
+    def forward(self, X: np.ndarray) -> np.ndarray:
+        _assert_ndarray(X, "X")
+        if X.shape[1] != self.in_features:
+            raise ValueError(
+                f"Dimensión de entrada esperada {self.in_features}, recibida {X.shape[1]}"
+            )
+        Z = X @ self.W + self.b
+        return ACTIVATIONS[self.activation_name](Z)
+
+
+class MLP:
+    """Minimalist Multi Layer Perceptron composed of :class:`Layer` objects."""
+
+    def __init__(self, layers: Iterable[Layer]):
+        self.layers: List[Layer] = list(layers)
+        if not self.layers:
+            raise ValueError("Se requiere al menos una capa")
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        out = X
+        for layer in self.layers:
+            out = layer.forward(out)
+        return out

--- a/src/mlp_compiler/training.py
+++ b/src/mlp_compiler/training.py
@@ -1,0 +1,90 @@
+"""Helper utilities for training models built from the textual compiler."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+from tensorflow import keras
+from tensorflow.keras import utils
+from tensorflow.keras.datasets import mnist
+
+from .compiler import compile_model
+
+
+@dataclass
+class TrainingResult:
+    model: keras.Model
+    history: Dict[str, list]
+    test_loss: float
+    test_accuracy: float
+
+
+DatasetSplit = Tuple[np.ndarray, np.ndarray]
+Dataset = Tuple[DatasetSplit, DatasetSplit]
+
+
+def load_mnist(
+    *,
+    normalize: bool = True,
+    flatten: bool = True,
+    one_hot: bool = True,
+    limit_train: Optional[int] = None,
+    limit_test: Optional[int] = None,
+) -> Dataset:
+    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+
+    if limit_train is not None:
+        x_train = x_train[:limit_train]
+        y_train = y_train[:limit_train]
+    if limit_test is not None:
+        x_test = x_test[:limit_test]
+        y_test = y_test[:limit_test]
+
+    if normalize:
+        x_train = x_train.astype("float32") / 255.0
+        x_test = x_test.astype("float32") / 255.0
+    if flatten:
+        x_train = x_train.reshape((x_train.shape[0], -1))
+        x_test = x_test.reshape((x_test.shape[0], -1))
+    if one_hot:
+        num_classes = int(y_train.max() + 1)
+        y_train = utils.to_categorical(y_train, num_classes)
+        y_test = utils.to_categorical(y_test, num_classes)
+    return (x_train, y_train), (x_test, y_test)
+
+
+def build_and_train(
+    architecture: str,
+    *,
+    input_dim: int,
+    epochs: int = 5,
+    batch_size: int = 128,
+    validation_split: float = 0.1,
+    verbose: int = 1,
+    limit_train: Optional[int] = None,
+    limit_test: Optional[int] = None,
+) -> TrainingResult:
+    (x_train, y_train), (x_test, y_test) = load_mnist(
+        limit_train=limit_train, limit_test=limit_test
+    )
+
+    model = compile_model(architecture, input_dim=input_dim)
+    model.compile(optimizer="adam", loss="categorical_crossentropy", metrics=["accuracy"])
+
+    history = model.fit(
+        x_train,
+        y_train,
+        validation_split=validation_split,
+        epochs=epochs,
+        batch_size=batch_size,
+        verbose=verbose,
+    )
+
+    test_loss, test_accuracy = model.evaluate(x_test, y_test, verbose=0)
+    return TrainingResult(
+        model=model,
+        history=history.history,
+        test_loss=float(test_loss),
+        test_accuracy=float(test_accuracy),
+    )

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,132 @@
+"""Flask application to experiment with the MLP compiler through a web UI."""
+from __future__ import annotations
+
+import base64
+import io
+from dataclasses import dataclass
+
+from flask import Flask, render_template, request
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+
+from mlp_compiler.training import TrainingResult, build_and_train
+
+app = Flask(__name__)
+
+DEFAULT_ARCHITECTURE = "Dense(300, relu) -> Dropout(0.2) -> Dense(100, relu) -> Dense(10, softmax)"
+
+
+@dataclass
+class FormData:
+    architecture: str
+    epochs: int
+    batch_size: int
+    validation_split: float
+    train_size: int | None
+
+
+@dataclass
+class TrainingView:
+    accuracy_plot: str
+    loss_plot: str
+    test_accuracy: float
+    test_loss: float
+
+
+def _get_form_data() -> FormData:
+    def _int(value: str, default: int) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    def _float(value: str, default: float) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    architecture = request.form.get("architecture", DEFAULT_ARCHITECTURE)
+    epochs = _int(request.form.get("epochs"), 3)
+    batch_size = _int(request.form.get("batch_size"), 128)
+    validation_split = _float(request.form.get("validation_split"), 0.1)
+    train_size_raw = request.form.get("train_size")
+    train_size = _int(train_size_raw, 5000) if train_size_raw else 5000
+    if train_size <= 0:
+        train_size = None
+
+    return FormData(
+        architecture=architecture,
+        epochs=max(1, epochs),
+        batch_size=max(1, batch_size),
+        validation_split=min(max(validation_split, 0.05), 0.4),
+        train_size=train_size,
+    )
+
+
+def _plot_history(history: TrainingResult) -> tuple[str, str]:
+    def _plot(metric: str, val_metric: str, title: str, ylabel: str) -> str:
+        fig, ax = plt.subplots(figsize=(5, 3))
+        ax.plot(history.history.get(metric, []), label="train")
+        if val_metric in history.history:
+            ax.plot(history.history.get(val_metric, []), label="val")
+        ax.set_title(title)
+        ax.set_xlabel("Época")
+        ax.set_ylabel(ylabel)
+        ax.legend()
+        ax.grid(True)
+        fig.tight_layout()
+        buffer = io.BytesIO()
+        fig.savefig(buffer, format="png")
+        plt.close(fig)
+        buffer.seek(0)
+        return base64.b64encode(buffer.read()).decode("ascii")
+
+    acc_plot = _plot("accuracy", "val_accuracy", "Evolución de Accuracy", "Accuracy")
+    loss_plot = _plot("loss", "val_loss", "Evolución de la Pérdida", "Loss")
+    return acc_plot, loss_plot
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    error: str | None = None
+    view: TrainingView | None = None
+    form_data = FormData(
+        architecture=DEFAULT_ARCHITECTURE,
+        epochs=3,
+        batch_size=128,
+        validation_split=0.1,
+        train_size=5000,
+    )
+
+    if request.method == "POST":
+        form_data = _get_form_data()
+        try:
+            result = build_and_train(
+                form_data.architecture,
+                input_dim=784,
+                epochs=form_data.epochs,
+                batch_size=form_data.batch_size,
+                validation_split=form_data.validation_split,
+                limit_train=form_data.train_size,
+                limit_test=1000,
+                verbose=0,
+            )
+            acc_plot, loss_plot = _plot_history(result)
+            view = TrainingView(
+                accuracy_plot=acc_plot,
+                loss_plot=loss_plot,
+                test_accuracy=result.test_accuracy,
+                test_loss=result.test_loss,
+            )
+        except Exception as exc:  # pragma: no cover - web runtime
+            error = str(exc)
+
+    return render_template("index.html", form_data=form_data, view=view, error=error)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -1,0 +1,110 @@
+:root {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #222;
+  background: #f4f5f7;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+  background: #ffffff;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 2.25rem;
+}
+
+.lead {
+  color: #555;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+textarea,
+input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #cfd3d9;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+textarea:focus,
+input:focus {
+  outline: none;
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.15);
+}
+
+button {
+  align-self: flex-start;
+  background: #4f46e5;
+  border: none;
+  border-radius: 6px;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease-in-out;
+}
+
+button:hover {
+  background: #4338ca;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.alert {
+  padding: 1rem;
+  border-radius: 6px;
+  margin-top: 1rem;
+}
+
+.alert-error {
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  color: #991b1b;
+}
+
+.results {
+  margin-top: 2rem;
+}
+
+.plots {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+figure {
+  margin: 0;
+  background: #f9fafb;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: inset 0 0 0 1px #e5e7eb;
+}
+
+figcaption {
+  text-align: center;
+  margin-top: 0.5rem;
+  color: #555;
+}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8">
+    <title>Intérprete de MLP</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  </head>
+  <body>
+    <main class="container">
+      <h1>Intérprete de Redes Neuronales</h1>
+      <p class="lead">
+        Describe tu arquitectura con el mini-lenguaje y entrena un modelo sobre MNIST directamente desde la web.
+      </p>
+
+      {% if error %}
+      <div class="alert alert-error">
+        <strong>Error:</strong> {{ error }}
+      </div>
+      {% endif %}
+
+      <form method="post" class="form">
+        <label for="architecture">Arquitectura</label>
+        <textarea id="architecture" name="architecture" rows="2">{{ form_data.architecture }}</textarea>
+
+        <div class="form-grid">
+          <div>
+            <label for="epochs">Épocas</label>
+            <input id="epochs" name="epochs" type="number" min="1" value="{{ form_data.epochs }}">
+          </div>
+          <div>
+            <label for="batch_size">Batch size</label>
+            <input id="batch_size" name="batch_size" type="number" min="1" value="{{ form_data.batch_size }}">
+          </div>
+          <div>
+            <label for="validation_split">Validación</label>
+            <input id="validation_split" name="validation_split" type="number" step="0.01" min="0.05" max="0.4" value="{{ form_data.validation_split }}">
+          </div>
+          <div>
+            <label for="train_size">Ejemplos entrenamiento</label>
+            <input id="train_size" name="train_size" type="number" min="0" value="{{ form_data.train_size }}">
+          </div>
+        </div>
+
+        <button type="submit">Entrenar modelo</button>
+      </form>
+
+      {% if view %}
+      <section class="results">
+        <h2>Resultados</h2>
+        <p>Precisión en test: <strong>{{ '%.4f'|format(view.test_accuracy) }}</strong></p>
+        <p>Pérdida en test: <strong>{{ '%.4f'|format(view.test_loss) }}</strong></p>
+        <div class="plots">
+          <figure>
+            <img src="data:image/png;base64,{{ view.accuracy_plot }}" alt="Accuracy durante el entrenamiento">
+            <figcaption>Accuracy</figcaption>
+          </figure>
+          <figure>
+            <img src="data:image/png;base64,{{ view.loss_plot }}" alt="Pérdida durante el entrenamiento">
+            <figcaption>Pérdida</figcaption>
+          </figure>
+        </div>
+      </section>
+      {% endif %}
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- estructurar el MLP en NumPy y el compilador de arquitecturas como un paquete instalable
- añadir utilidades de entrenamiento sobre MNIST con script CLI y respuestas de análisis
- crear interfaz web con Flask para probar arquitecturas y visualizar métricas

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d3fe861b308322adc1054c35968615