### PR TITLE
Add helper script to launch Flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,14 @@ Si añades `--plot-path outputs/history.png` el script guardará las curvas de a
 1. Arranca el servidor Flask:
 
    ```bash
-   export FLASK_APP=web.app
-   flask run
+   ./scripts/run_web.sh
    ```
 
-   También puedes ejecutar `python web/app.py` para modo *debug*.
+   El script se encarga de exportar las variables de entorno necesarias y, en caso de
+   no encontrar el comando `flask`, instalará automáticamente las dependencias
+   listadas en `requirements.txt`. Si prefieres hacerlo manualmente, puedes ejecutar
+   `export FLASK_APP=web.app` seguido de `flask run`, o lanzar `python web/app.py` para
+   el modo *debug*.
 
 2. Visita `http://127.0.0.1:5000` y completa el formulario. El servidor entrenará el modelo usando 5 000 ejemplos por defecto para ofrecer una respuesta rápida y mostrará las métricas y gráficas generadas.
 

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine repository root (directory containing this script's parent)
+REPO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$REPO_DIR"
+
+# Ensure the src/ package is importable when running Flask
+export PYTHONPATH="$REPO_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
+
+# Configure Flask entry point
+export FLASK_APP=web.app
+
+if ! command -v flask >/dev/null 2>&1; then
+    echo "[run_web] No se encontró el comando 'flask'. Instalando dependencias..."
+    pip install --user -r requirements.txt
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+echo "[run_web] Lanzando la aplicación Flask en http://127.0.0.1:5000"
+exec flask run --host=127.0.0.1 --port=5000 "$@"


### PR DESCRIPTION
## Summary
- add a helper shell script that exports the required environment and runs the Flask app
- document the new script in the README so the web UI can be launched with a single command

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4530375a8832297bbd9b18e75ac89