### PR TITLE
Fix Flask launcher script when command isn't on PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,14 @@ Si añades `--plot-path outputs/history.png` el script guardará las curvas de a
 1. Arranca el servidor Flask:
 
    ```bash
-   export FLASK_APP=web.app
-   flask run
+   ./scripts/run_web.sh
    ```
 
-   También puedes ejecutar `python web/app.py` para modo *debug*.
+   El script se encarga de exportar las variables de entorno necesarias y, en caso de
+   no encontrar Flask instalado para `python3`, instalará automáticamente las
+   dependencias listadas en `requirements.txt`. Si prefieres hacerlo manualmente,
+   puedes ejecutar `export FLASK_APP=web.app` seguido de `python3 -m flask run`, o
+   lanzar `python web/app.py` para el modo *debug*.
 
 2. Visita `http://127.0.0.1:5000` y completa el formulario. El servidor entrenará el modelo usando 5 000 ejemplos por defecto para ofrecer una respuesta rápida y mostrará las métricas y gráficas generadas.
 

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine repository root (directory containing this script's parent)
+REPO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$REPO_DIR"
+
+# Ensure the src/ package is importable when running Flask
+export PYTHONPATH="$REPO_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
+
+# Configure Flask entry point
+export FLASK_APP=web.app
+
+if ! python3 -m flask --version >/dev/null 2>&1; then
+    echo "[run_web] No se encontró Flask en el entorno actual. Instalando dependencias..."
+    python3 -m pip install --user -r requirements.txt
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+echo "[run_web] Lanzando la aplicación Flask en http://127.0.0.1:5000"
+exec python3 -m flask run --host=127.0.0.1 --port=5000 "$@"


### PR DESCRIPTION
## Summary
- run the helper script through `python3 -m flask` so it works even if the `flask` command is missing
- install dependencies with `python3 -m pip` and document the new invocation in the README

## Testing
- ./scripts/run_web.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68d4530375a8832297bbd9b18e75ac89