### PR TITLE
Simplify launching the Flask demo and fix import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,19 @@ Este repositorio traslada el trabajo realizado en Google Colab a un proyecto est
 
 ## Requisitos
 
-```bash
-python >= 3.9
-pip install -r requirements.txt
-```
+1. Instala Python 3.9 o superior.
+2. (Opcional pero recomendado) crea un entorno virtual:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # En Windows usa: .venv\Scripts\Activate.ps1
+   ```
+
+3. Instala las dependencias:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
 
 > **Nota**: TensorFlow puede tardar en instalarse dependiendo de la plataforma. Si cuentas con GPU puedes instalar `tensorflow-gpu`.
 
@@ -48,17 +57,26 @@ Si añades `--plot-path outputs/history.png` el script guardará las curvas de a
 
 ## Interfaz web
 
-1. Arranca el servidor Flask:
+1. Arranca el servidor Flask (elige la opción que prefieras):
 
-   ```bash
-   ./scripts/run_web.sh
-   ```
+   - **Windows / macOS / Linux**:
 
-   El script se encarga de exportar las variables de entorno necesarias y, en caso de
-   no encontrar el comando `flask`, instalará automáticamente las dependencias
-   listadas en `requirements.txt`. Si prefieres hacerlo manualmente, puedes ejecutar
-   `export FLASK_APP=web.app` seguido de `flask run`, o lanzar `python web/app.py` para
-   el modo *debug*.
+     ```bash
+     python scripts/run_web.py
+     ```
+
+   - **Bash** (por ejemplo desde Git Bash en Windows):
+
+     ```bash
+     ./scripts/run_web.sh
+     ```
+
+   Ambos comandos configuran automáticamente `PYTHONPATH`, establecen el módulo Flask y
+   lanzan el servidor en `http://127.0.0.1:5000`. Si Flask no está instalado, primero
+   ejecutarán `pip install -r requirements.txt`.
+
+   Como alternativa manual puedes ejecutar `python web/app.py` (modo debug) o
+   `python -m flask --app web.app run` después de exportar/definir `FLASK_APP`.
 
 2. Visita `http://127.0.0.1:5000` y completa el formulario. El servidor entrenará el modelo usando 5 000 ejemplos por defecto para ofrecer una respuesta rápida y mostrará las métricas y gráficas generadas.
 

--- a/scripts/run_web.py
+++ b/scripts/run_web.py
@@ -1,0 +1,60 @@
+"""Cross-platform launcher for the Flask demo application."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final
+
+
+def ensure_dependencies(requirements: Path) -> None:
+    """Install Flask (and the rest of the requirements) if it is missing."""
+
+    try:  # pragma: no cover - runtime dependency check
+        import flask  # type: ignore  # noqa: F401
+        return
+    except ModuleNotFoundError:
+        pass
+
+    print("[run_web] Instalando dependencias listadas en requirements.txt...")
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "-r",
+        str(requirements),
+    ])
+
+
+def main() -> None:
+    repo_dir: Final[Path] = Path(__file__).resolve().parents[1]
+    requirements = repo_dir / "requirements.txt"
+    src_dir = repo_dir / "src"
+
+    ensure_dependencies(requirements)
+
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    new_pythonpath = str(src_dir)
+    if pythonpath:
+        new_pythonpath = f"{new_pythonpath}{os.pathsep}{pythonpath}"
+    env["PYTHONPATH"] = new_pythonpath
+    env.setdefault("FLASK_APP", "web.app")
+
+    print("[run_web] Lanzando la aplicación Flask en http://127.0.0.1:5000")
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "flask",
+        "run",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "5000",
+    ], env=env)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -5,17 +5,9 @@ set -euo pipefail
 REPO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$REPO_DIR"
 
-# Ensure the src/ package is importable when running Flask
-export PYTHONPATH="$REPO_DIR/src${PYTHONPATH:+:$PYTHONPATH}"
-
-# Configure Flask entry point
-export FLASK_APP=web.app
-
-if ! command -v flask >/dev/null 2>&1; then
-    echo "[run_web] No se encontró el comando 'flask'. Instalando dependencias..."
-    pip install --user -r requirements.txt
-    export PATH="$HOME/.local/bin:$PATH"
+PYTHON_BIN="${PYTHON:-${PYTHON3:-python3}}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    PYTHON_BIN=python
 fi
 
-echo "[run_web] Lanzando la aplicación Flask en http://127.0.0.1:5000"
-exec flask run --host=127.0.0.1 --port=5000 "$@"
+exec "$PYTHON_BIN" "$REPO_DIR/scripts/run_web.py" "$@"

--- a/scripts/train_mnist.py
+++ b/scripts/train_mnist.py
@@ -2,10 +2,17 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 from typing import Optional
 
 import matplotlib.pyplot as plt
+
+# Ensure the src/ directory is importable when the script is run directly.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if SRC_DIR.exists():  # pragma: no branch - guard against missing path
+    sys.path.insert(0, str(SRC_DIR))
 
 from mlp_compiler.training import TrainingResult, build_and_train
 

--- a/web/app.py
+++ b/web/app.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import base64
 import io
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 from flask import Flask, render_template, request
 import matplotlib
@@ -11,6 +13,11 @@ import matplotlib
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if SRC_DIR.exists():  # pragma: no branch - guard against missing path
+    sys.path.insert(0, str(SRC_DIR))
 
 from mlp_compiler.training import TrainingResult, build_and_train
 


### PR DESCRIPTION
## Summary
- add a cross-platform Python launcher for the Flask web UI and delegate the bash script to it
- make the CLI and web entrypoints add the project src/ folder to PYTHONPATH automatically
- refresh the README with clearer setup steps for Windows, macOS and Linux users

## Testing
- `python scripts/train_mnist.py --epochs 1 --train-size 128 --test-size 128 --batch-size 64 --validation-split 0.1` *(fails: MNIST download blocked by proxy)*
- `python scripts/run_web.py` *(terminated manually with Ctrl+C after verifying startup)*

------
https://chatgpt.com/codex/tasks/task_e_68d501dc75f08322af7d60f9bdad8123